### PR TITLE
✅ [CHORE] 탭 바 shadow 수정 및 알럿창 이미지 커스텀 가능하도록 수정

### DIFF
--- a/POME-iOS/POME-iOS/Global/UIComponent/Class/PomeAlertVC.swift
+++ b/POME-iOS/POME-iOS/Global/UIComponent/Class/PomeAlertVC.swift
@@ -100,11 +100,12 @@ extension PomeAlertVC {
 extension PomeAlertVC {
     
     /// 알럿 보여주는 메서드
-    func showPomeAlertVC(vc: UIViewController, title: String, subTitle: String, cancelBtnTitle: String, confirmBtnTitle: String) {
+    func showPomeAlertVC(vc: UIViewController, title: String, subTitle: String, cancelBtnTitle: String, confirmBtnTitle: String, iconImage: UIImage? = UIImage(named: "3DTrashCanMint100")) {
         titleLabel.text = title
         subTitleLabel.text = subTitle
         cancelBtn.setTitle(cancelBtnTitle, for: .normal)
         confirmBtn.setTitle(confirmBtnTitle, for: .normal)
+        iconImageView.image = iconImage
         
         self.modalPresentationStyle = .overFullScreen
         self.modalTransitionStyle = .crossDissolve

--- a/POME-iOS/POME-iOS/Global/UIComponent/Class/PomeMaskedImageView.swift
+++ b/POME-iOS/POME-iOS/Global/UIComponent/Class/PomeMaskedImageView.swift
@@ -25,7 +25,7 @@ class PomeMaskedImageView: UIImageView {
         updateImageView()
     }
     
-    /// mask가 적용된 이미지로 적용해주는 메서드
+    /// 원본 이미지에 mask를 적용해주는 메서드
     private func updateImageView() {
         if maskImageView.image != nil {
             maskImageView.frame = bounds

--- a/POME-iOS/POME-iOS/Screen/TabBar/VC/PomeTBC.swift
+++ b/POME-iOS/POME-iOS/Screen/TabBar/VC/PomeTBC.swift
@@ -58,7 +58,7 @@ extension PomeTBC {
     func applyShadowTabBar() {
         
         UITabBar.clearShadow()
-        tabBar.layer.applyShadow(color: UIColor.shadowDefault, alpha: 1, x: 0, y: -40, blur: 18)
+        tabBar.layer.applyShadow(color: UIColor.shadowDefault, alpha: 0.6, x: 0, y: -10, blur: 14)
 
     }
 }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #42

## 🍎 변경 사항 및 이유
- 탭 바 shadow 값을 수정하고, 알럿창 이미지 커스텀이 가능하도록 코드를 수정했습니다.

## 🍎 PR Point
### 알럿창 이미지 커스텀 방법
```Swift
private func tapConfirmBtn() {
        let alert = PomeAlertVC()
        
        confirmBtn.press {
            alert.showPomeAlertVC(vc: self, title: "기록을 중단하시겠어요?", subTitle: "하이하이", cancelBtnTitle: "아니요", confirmBtnTitle: "중단할래요", iconImage: UIImage(named: "icPlus24"))
        }
    }

```
기존 방법과 동일한데, 이미지를 커스텀해서 사용하고 싶다면 뒤에 `iconImage`파라미터를 하나 더 추가해서 적용해주고 싶은 이미지를 넣어주면 됩니다.
원래의 이미지를 그대로 사용하는 경우라면 `iconImage` 파라미터를 써주지 않아도 됩니다!!

## 📸 ScreenShot
<img width="300" alt="스크린샷 2022-07-13 오전 5 00 37" src="https://user-images.githubusercontent.com/63277563/178583478-6383cabe-7159-483f-90cc-281eb758269a.png">