### PR TITLE
✨ [FEAT] 바텀시트 제작 

### DIFF
--- a/POME-iOS/POME-iOS.xcodeproj/project.pbxproj
+++ b/POME-iOS/POME-iOS.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		1A76CACE287B1B3300B29500 /* MateHeaderCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A76CACC287B1B3300B29500 /* MateHeaderCVC.swift */; };
 		1A76CACF287B1B3300B29500 /* MateHeaderCVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1A76CACD287B1B3300B29500 /* MateHeaderCVC.xib */; };
 		778E0F432879624700BEEEA5 /* PomeTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 778E0F422879624700BEEEA5 /* PomeTextField.swift */; };
-		778E0F432879624700BEEEA5 /* PomeTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 778E0F422879624700BEEEA5 /* PomeTextField.swift */; };
 		778E0F452879FB5500BEEEA5 /* PomeMaskedImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 778E0F442879FB5500BEEEA5 /* PomeMaskedImageView.swift */; };
 		778E0F50287B273900BEEEA5 /* SignSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 778E0F4F287B273900BEEEA5 /* SignSB.storyboard */; };
 		778E0F52287B27AB00BEEEA5 /* MakeProfileVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 778E0F51287B27AB00BEEEA5 /* MakeProfileVC.swift */; };
@@ -98,6 +97,7 @@
 		8432C9BB28784533001C643F /* EmptyGoalCardCVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8432C9BA28784533001C643F /* EmptyGoalCardCVC.xib */; };
 		8432C9BD28784751001C643F /* FeelingCardCVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8432C9BC28784751001C643F /* FeelingCardCVC.xib */; };
 		8432C9BF28787F9A001C643F /* FeelingCardCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8432C9BE28787F9A001C643F /* FeelingCardCVC.swift */; };
+		84A6E883287D518200CD5843 /* PomeHalfModalVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A6E882287D518200CD5843 /* PomeHalfModalVC.swift */; };
 		84ACED852878989E00AA408D /* EmptyGoalCardCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84ACED842878989E00AA408D /* EmptyGoalCardCVC.swift */; };
 		84B77272287B369200E1EDFC /* LookbackCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B77270287B369200E1EDFC /* LookbackCVC.swift */; };
 		84B77273287B369200E1EDFC /* LookbackCVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84B77271287B369200E1EDFC /* LookbackCVC.xib */; };
@@ -202,6 +202,7 @@
 		8432C9BA28784533001C643F /* EmptyGoalCardCVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EmptyGoalCardCVC.xib; sourceTree = "<group>"; };
 		8432C9BC28784751001C643F /* FeelingCardCVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FeelingCardCVC.xib; sourceTree = "<group>"; };
 		8432C9BE28787F9A001C643F /* FeelingCardCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeelingCardCVC.swift; sourceTree = "<group>"; };
+		84A6E882287D518200CD5843 /* PomeHalfModalVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomeHalfModalVC.swift; sourceTree = "<group>"; };
 		84ACED842878989E00AA408D /* EmptyGoalCardCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyGoalCardCVC.swift; sourceTree = "<group>"; };
 		84B77270287B369200E1EDFC /* LookbackCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookbackCVC.swift; sourceTree = "<group>"; };
 		84B77271287B369200E1EDFC /* LookbackCVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LookbackCVC.xib; sourceTree = "<group>"; };
@@ -757,6 +758,7 @@
 				778E0F422879624700BEEEA5 /* PomeTextField.swift */,
 				778E0F442879FB5500BEEEA5 /* PomeMaskedImageView.swift */,
 				778E0F53287C43D300BEEEA5 /* PomeAlertVC.swift */,
+				84A6E882287D518200CD5843 /* PomeHalfModalVC.swift */,
 			);
 			path = Class;
 			sourceTree = "<group>";
@@ -918,6 +920,7 @@
 				77E8F33A28759FCF00D2F6C0 /* UIFont+.swift in Sources */,
 				77E8F3732876934500D2F6C0 /* APIConstants.swift in Sources */,
 				84ACED852878989E00AA408D /* EmptyGoalCardCVC.swift in Sources */,
+				84A6E883287D518200CD5843 /* PomeHalfModalVC.swift in Sources */,
 				77E8F3202874B7E500D2F6C0 /* MypageTVC.swift in Sources */,
 				77E8F36028765FA600D2F6C0 /* RemindNC.swift in Sources */,
 				77E8F31E2874B7CE00D2F6C0 /* MypageVC.swift in Sources */,
@@ -980,7 +983,7 @@
 				77E8F3102874B50500D2F6C0 /* MateVC.swift in Sources */,
 				77E8F34E2875F45600D2F6C0 /* BaseVC.swift in Sources */,
 				77E8F334287574B000D2F6C0 /* UITextField+.swift in Sources */,
-				84B7727D287BD83D00E1EDFC /* SelectFeelingVC.swift in Sources */,
+				84B7727D287BD83D00E1EDFC /* LookbackSelectVC.swift in Sources */,
 				84B7727D287BD83D00E1EDFC /* LookbackSelectVC.swift in Sources */,
 				77E8F3662876606D00D2F6C0 /* ViewControllerFactory.swift in Sources */,
 				77E8F379287693AA00D2F6C0 /* WriteService.swift in Sources */,

--- a/POME-iOS/POME-iOS/Global/UIComponent/Class/PomeHalfModalVC.swift
+++ b/POME-iOS/POME-iOS/Global/UIComponent/Class/PomeHalfModalVC.swift
@@ -51,7 +51,9 @@ class PomeHalfModalVC: UIPresentationController {
     /// 하프 모달 뷰 radius 설정
     override func containerViewWillLayoutSubviews() {
         super.containerViewWillLayoutSubviews()
-        presentedView!.makeRounded(cornerRadius: 16.adjusted)
+        presentedView?.clipsToBounds = true
+        presentedView?.layer.cornerRadius = 16.adjusted
+        presentedView?.layer.maskedCorners = CACornerMask(arrayLiteral: .layerMinXMinYCorner, .layerMaxXMinYCorner)
     }
     
     /// 하위뷰 배치가 마쳤음을 알림 이후 VC 변경됨

--- a/POME-iOS/POME-iOS/Global/UIComponent/Class/PomeHalfModalVC.swift
+++ b/POME-iOS/POME-iOS/Global/UIComponent/Class/PomeHalfModalVC.swift
@@ -1,0 +1,72 @@
+//
+//  PomeHalfModalVC.swift
+//  POME-iOS
+//
+//  Created by Juhyeon Byun on 2022/07/12.
+//
+
+import UIKit
+
+class PomeHalfModalVC: UIPresentationController {
+    
+    // MARK: Properties
+    let backView = UIView()
+    var tapGestureRecognizer: UITapGestureRecognizer = UITapGestureRecognizer()
+    var modalHeight: CGFloat = 0
+    
+    /// 배경 (반투명 검정)에 대한 처리
+    override init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?) {
+        backView.backgroundColor = UIColor.black
+        super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
+        tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissController))
+        backView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        self.backView.isUserInteractionEnabled = true
+        self.backView.addGestureRecognizer(tapGestureRecognizer)
+    }
+    
+    /// 보여질 HalfModalView 프레임 설정
+    override var frameOfPresentedViewInContainerView: CGRect {
+        CGRect(origin: CGPoint(x: 0, y: self.containerView!.frame.height * CGFloat(812 - modalHeight)/812),
+               size: CGSize(width: self.containerView!.frame.width, height: self.containerView!.frame.height  * CGFloat(modalHeight)/812))
+    }
+    
+    /// present 시작할 때
+    override func presentationTransitionWillBegin() {
+        self.backView.alpha = 0
+        self.containerView?.addSubview(backView)
+        self.presentedViewController.transitionCoordinator?.animate(alongsideTransition: { (UIViewControllerTransitionCoordinatorContext) in
+            self.backView.alpha = 0.5
+        }, completion: { (UIViewControllerTransitionCoordinatorContext) in })
+    }
+    
+    /// dismiss 시작될 때
+    override func dismissalTransitionWillBegin() {
+        self.presentedViewController.transitionCoordinator?.animate(alongsideTransition: { (UIViewControllerTransitionCoordinatorContext) in
+            self.backView.alpha = 0
+        }, completion: { (UIViewControllerTransitionCoordinatorContext) in
+            self.backView.removeFromSuperview()
+        })
+    }
+    
+    /// 하프 모달 뷰 radius 설정
+    override func containerViewWillLayoutSubviews() {
+        super.containerViewWillLayoutSubviews()
+        presentedView!.makeRounded(cornerRadius: 16.adjusted)
+    }
+    
+    /// 하위뷰 배치가 마쳤음을 알림 이후 VC 변경됨
+    override func containerViewDidLayoutSubviews() {
+        super.containerViewDidLayoutSubviews()
+        presentedView?.frame = frameOfPresentedViewInContainerView
+        backView.frame = containerView!.bounds
+    }
+}
+
+// MARK: - @objc
+extension PomeHalfModalVC {
+    
+    /// dismiss처리
+    @objc func dismissController(){
+        self.presentedViewController.dismiss(animated: true, completion: nil)
+    }
+}

--- a/POME-iOS/POME-iOS/Global/UIComponent/Class/PomeHalfModalVC.swift
+++ b/POME-iOS/POME-iOS/Global/UIComponent/Class/PomeHalfModalVC.swift
@@ -35,7 +35,7 @@ class PomeHalfModalVC: UIPresentationController {
         self.backView.alpha = 0
         self.containerView?.addSubview(backView)
         self.presentedViewController.transitionCoordinator?.animate(alongsideTransition: { (UIViewControllerTransitionCoordinatorContext) in
-            self.backView.alpha = 0.5
+            self.backView.alpha = 0.45
         }, completion: { (UIViewControllerTransitionCoordinatorContext) in })
     }
     

--- a/POME-iOS/POME-iOS/Screen/Write/VC/LookbackVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Write/VC/LookbackVC.swift
@@ -33,6 +33,20 @@ extension LookbackVC {
     }
 }
 
+// MARK: - Custom Methods
+extension LookbackVC {
+    
+    private func setDelegate() {
+        lookbackMainCV.delegate = self
+        lookbackMainCV.dataSource = self
+    }
+    
+    private func registerCV() {
+        LookbackCVC.register(target: lookbackMainCV)
+        SpendCVC.register(target: lookbackMainCV)
+    }
+}
+
 // MARK: - UICollectionViewDataSource
 extension LookbackVC: UICollectionViewDataSource {
     
@@ -104,18 +118,4 @@ extension LookbackVC: UICollectionViewDelegateFlowLayout {
     /// CV, 섹션 별 셀 좌우 간격 설정
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
         return (section == 0) ? 0 : 11
-}
-
-// MARK: - Custom Methods
-extension LookbackVC {
-    
-    private func setDelegate() {
-        lookbackMainCV.delegate = self
-        lookbackMainCV.dataSource = self
-    }
-    
-    private func registerCV() {
-        LookbackCVC.register(target: lookbackMainCV)
-        SpendCVC.register(target: lookbackMainCV)
-    }
 }

--- a/POME-iOS/POME-iOS/Screen/Write/VC/WriteVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Write/VC/WriteVC.swift
@@ -48,6 +48,27 @@ extension WriteVC {
     }
 }
 
+// MARK: - Custom Methods
+extension WriteVC {
+    
+    private func setDelegate() {
+        writeMainCV.delegate = self
+        writeMainCV.dataSource = self
+        goalCategoryCV.delegate = self
+        goalCategoryCV.dataSource = self
+    }
+    
+    private func registerCV() {
+        FeelingCardCVC.register(target: writeMainCV)
+        EmptyGoalCardCVC.register(target: writeMainCV)
+        SpendCVC.register(target: writeMainCV)
+        
+        // TODO: - GoalCardCVC 등록 필요
+        // GoalCardCVC.register(target: writeMainCV)
+        GoalCategoryCVC.register(target: goalCategoryCV)
+    }
+}
+
 // MARK: - UICollectionViewDataSource
 extension WriteVC: UICollectionViewDataSource {
     
@@ -163,26 +184,5 @@ extension WriteVC: UICollectionViewDelegateFlowLayout {
                 return 11
             }
         }
-    }
-}
-
-// MARK: - Custom Methods
-extension WriteVC {
-    
-    private func setDelegate() {
-        writeMainCV.delegate = self
-        writeMainCV.dataSource = self
-        goalCategoryCV.delegate = self
-        goalCategoryCV.dataSource = self
-    }
-    
-    private func registerCV() {
-        FeelingCardCVC.register(target: writeMainCV)
-        EmptyGoalCardCVC.register(target: writeMainCV)
-        SpendCVC.register(target: writeMainCV)
-        
-        // TODO: - GoalCardCVC 등록 필요
-        // GoalCardCVC.register(target: writeMainCV)
-        GoalCategoryCVC.register(target: goalCategoryCV)
     }
 }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #37 

## 🍎 변경 사항 및 이유
* 컨벤션에 따라 LookBackVC, WriteVC의 Custom Methods 부분을 UI 다음에 배치하였습니다.
* 재사용 가능한 바텀 시트를 제작하였습니다.
    * 배경을 누르면 바텀 시트가 내려갑니다. 

## 🍎 PR Point
### 사용방법
1. 다음과 같이 바텀시트로 띄울 VC 파일을 생성합니다. 
<img width="463" alt="image" src="https://user-images.githubusercontent.com/58043306/178799368-766e1f5a-5ebc-4812-85b6-bf9a83966945.png">

2. 바텀시트를 띄울 뷰의 VC에 아래 코드를 추가합니다.
    * `halfModalVC.modalHeight = 100`코드에서 바텀시트 높이를 지정해줄 수 있습니다.
``` swift
// MARK: - @objc
extension LookbackCompleteVC {
    
    /// 만들어 둔 HalfModalVC 보여주는 함수
    @objc func showHalfModalVC() {
        let halfModalVC = CheckVC()
        halfModalVC.modalPresentationStyle = .custom
        halfModalVC.transitioningDelegate = self
        self.present(halfModalVC, animated: true, completion: nil)
    }
}

// MARK: - UIViewControllerTransitioningDelegate
extension LookbackCompleteVC: UIViewControllerTransitioningDelegate {
    
    func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
        let halfModalVC = PomeHalfModalVC(presentedViewController: presented, presenting: presenting)
        
        /// HalfModalView의 높이 지정
        halfModalVC.modalHeight = 100
        return halfModalVC
    }
}
```

3. 버튼을 눌렀을 때 띄울 경우 아래와 같이 버튼을 눌렀을 때의 액션에 `showHalfModalView()`함수를 추가합니다.
    - 스토리보드로 작업하는 경우 `@IBAction`을 연결한 후 함수를 추가합니다.
``` swift 
    @IBAction func tapBottomSheetBtn(_ sender: UIButton) {
        showHalfModalVC()
    }
```

## 📸 ScreenShot
- height = 100(왼), 266(오)
<img width="300" alt="image" src="https://user-images.githubusercontent.com/58043306/178920255-2f9d67f3-9bac-4293-ab05-799a21e3e265.gif"> <img width="300" alt="image" src="https://user-images.githubusercontent.com/58043306/178920311-ffa02d5a-9aa5-449f-a79b-eb67d581e7c0.gif">
