### PR TITLE
✨ [FEAT] 기록탭 메인 목표 삭제 API

### DIFF
--- a/POME-iOS/POME-iOS.xcodeproj/project.pbxproj
+++ b/POME-iOS/POME-iOS.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		8400A408287C17C5004F2D49 /* LookbackCompleteVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8400A407287C17C5004F2D49 /* LookbackCompleteVC.swift */; };
 		84051AEF28815A0A007CF7EF /* WriteBottomAlertVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84051AED28815A0A007CF7EF /* WriteBottomAlertVC.swift */; };
 		84051AF028815A0A007CF7EF /* WriteBottomAlertVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84051AEE28815A0A007CF7EF /* WriteBottomAlertVC.xib */; };
+		8427F878288849690096B20E /* DeleteResModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8427F877288849690096B20E /* DeleteResModel.swift */; };
 		84309C822878ACF50017F8BF /* GoalCategoryCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84309C802878ACF50017F8BF /* GoalCategoryCVC.swift */; };
 		84309C832878ACF50017F8BF /* GoalCategoryCVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84309C812878ACF50017F8BF /* GoalCategoryCVC.xib */; };
 		8432C9B228773A42001C643F /* SpendCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8432C9B028773A42001C643F /* SpendCVC.swift */; };
@@ -287,6 +288,7 @@
 		8400A407287C17C5004F2D49 /* LookbackCompleteVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookbackCompleteVC.swift; sourceTree = "<group>"; };
 		84051AED28815A0A007CF7EF /* WriteBottomAlertVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteBottomAlertVC.swift; sourceTree = "<group>"; };
 		84051AEE28815A0A007CF7EF /* WriteBottomAlertVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = WriteBottomAlertVC.xib; sourceTree = "<group>"; };
+		8427F877288849690096B20E /* DeleteResModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteResModel.swift; sourceTree = "<group>"; };
 		84309C802878ACF50017F8BF /* GoalCategoryCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalCategoryCVC.swift; sourceTree = "<group>"; };
 		84309C812878ACF50017F8BF /* GoalCategoryCVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GoalCategoryCVC.xib; sourceTree = "<group>"; };
 		8432C9B028773A42001C643F /* SpendCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendCVC.swift; sourceTree = "<group>"; };
@@ -922,6 +924,7 @@
 				77BD150A288535D700A1950D /* SignInResModel.swift */,
 				843D538E288737AA00BB4DCB /* GetGoalsResModel.swift */,
 				843D53922887436C00BB4DCB /* GetGoalDetailResModel.swift */,
+				8427F877288849690096B20E /* DeleteResModel.swift */,
 			);
 			path = APIModels;
 			sourceTree = "<group>";
@@ -1192,6 +1195,7 @@
 				77E8F3712876931D00D2F6C0 /* NetworkResult.swift in Sources */,
 				77BD150D2885396400A1950D /* SignService.swift in Sources */,
 				77B571A6287FF6C400C9CC27 /* FriendProfileTVC.swift in Sources */,
+				8427F878288849690096B20E /* DeleteResModel.swift in Sources */,
 				778E0F432879624700BEEEA5 /* PomeTextField.swift in Sources */,
 				77E8F3562875F5A400D2F6C0 /* BaseTVC.swift in Sources */,
 				1A10C2562877349E00489CA1 /* GoalCardCVC.swift in Sources */,

--- a/POME-iOS/POME-iOS/Network/APIManagers/WriteAPI.swift
+++ b/POME-iOS/POME-iOS/Network/APIManagers/WriteAPI.swift
@@ -46,4 +46,21 @@ class WriteAPI: BaseAPI {
             }
         }
     }
+    
+    /// [DEETE] 목표 삭제
+    func deleteGoalAPI(goalId: Int, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        AFmanager.request(WriteService.deleteGoal(goalId: goalId)).responseData { response in
+            switch response.result {
+            case .success:
+                guard let statusCode = response.response?.statusCode else { return }
+                guard let data = response.data else { return }
+                
+                let networkResult = self.judgeStatus(by: statusCode, data, DeleteResModel.self)
+                completion(networkResult)
+                
+            case .failure(let err):
+                print(err.localizedDescription)
+            }
+        }
+    }
 }

--- a/POME-iOS/POME-iOS/Network/APIModels/DeleteResModel.swift
+++ b/POME-iOS/POME-iOS/Network/APIModels/DeleteResModel.swift
@@ -1,0 +1,13 @@
+//
+//  DeleteResModel.swift
+//  POME-iOS
+//
+//  Created by Juhyeon Byun on 2022/07/20.
+//
+
+import Foundation
+
+// MARK: DeleteResModel
+struct DeleteResModel: Codable {
+    let id: Int?
+}

--- a/POME-iOS/POME-iOS/Network/Services/WriteService.swift
+++ b/POME-iOS/POME-iOS/Network/Services/WriteService.swift
@@ -11,6 +11,7 @@ import Foundation
 enum WriteService {
     case getGoalGategory
     case getGoalDetail(goalId: Int)
+    case deleteGoal(goalId: Int)
 }
 
 extension WriteService: TargetType {
@@ -19,7 +20,7 @@ extension WriteService: TargetType {
         switch self {
         case .getGoalGategory:
             return "/goals"
-        case .getGoalDetail(let goalId):
+        case .getGoalDetail(let goalId), .deleteGoal(let goalId):
             return "/goals/\(goalId)"
         }
     }
@@ -28,6 +29,8 @@ extension WriteService: TargetType {
         switch self {
         case .getGoalGategory, .getGoalDetail:
             return .get
+        case .deleteGoal:
+            return .delete
         }
     }
     
@@ -35,7 +38,7 @@ extension WriteService: TargetType {
         switch self {
         case .getGoalGategory:
             return .requestPlain
-        case .getGoalDetail(let goalId):
+        case .getGoalDetail(let goalId), .deleteGoal(let goalId):
             let requestQuery: [String: Any] = [
                 "goalId": goalId
             ]
@@ -45,7 +48,7 @@ extension WriteService: TargetType {
     
     var header: HeaderType {
         switch self {
-        case .getGoalGategory, .getGoalDetail:
+        case .getGoalGategory, .getGoalDetail, .deleteGoal:
             return .auth
         }
     }

--- a/POME-iOS/POME-iOS/Screen/Write/SB/WriteSB.storyboard
+++ b/POME-iOS/POME-iOS/Screen/Write/SB/WriteSB.storyboard
@@ -7,6 +7,11 @@
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="Pretendard-SemiBold.otf">
+            <string>Pretendard-SemiBold</string>
+        </array>
+    </customFonts>
     <scenes>
         <!--WriteVC-->
         <scene sceneID="s0d-6b-0kx">
@@ -48,6 +53,24 @@
                                 </collectionViewFlowLayout>
                                 <cells/>
                             </collectionView>
+                            <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="GI5-Nb-w2x">
+                                <rect key="frame" x="123.66666666666666" y="549" width="127.66666666666666" height="53"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icNoting24" translatesAutoresizingMaskIntoConstraints="NO" id="3Ax-KG-0Ab">
+                                        <rect key="frame" x="51.999999999999986" y="0.0" width="24" height="24"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="3Ax-KG-0Ab" secondAttribute="height" multiplier="1:1" id="RF1-HP-8RL"/>
+                                            <constraint firstAttribute="width" constant="24" id="dL6-eb-njd"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="기록한 씀씀이가 없어요" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PNt-6p-zUb">
+                                        <rect key="frame" x="0.0" y="36" width="127.66666666666667" height="17"/>
+                                        <fontDescription key="fontDescription" name="Pretendard-SemiBold" family="Pretendard" pointSize="14"/>
+                                        <color key="textColor" name="grey_5"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rMY-oy-SiQ">
                                 <rect key="frame" x="307" y="710" width="52" height="52"/>
                                 <constraints>
@@ -71,15 +94,19 @@
                             <constraint firstItem="wNH-qz-TOz" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" id="ACX-fh-Pge"/>
                             <constraint firstItem="wNH-qz-TOz" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="BE3-JR-NOq"/>
                             <constraint firstItem="wNH-qz-TOz" firstAttribute="top" secondItem="zsx-4j-blm" secondAttribute="bottom" id="HCq-7d-rke"/>
+                            <constraint firstItem="GI5-Nb-w2x" firstAttribute="top" secondItem="zsx-4j-blm" secondAttribute="bottom" constant="419" id="M8G-bx-Vj5"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="Btg-DO-8q4" secondAttribute="trailing" id="W6E-49-HVJ"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="rMY-oy-SiQ" secondAttribute="trailing" constant="16" id="c82-GD-qma"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="zsx-4j-blm" secondAttribute="trailing" id="hEj-eE-hg5"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="rMY-oy-SiQ" secondAttribute="bottom" constant="16" id="lEY-Rn-PlE"/>
                             <constraint firstItem="wNH-qz-TOz" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="pRC-Rp-407"/>
+                            <constraint firstItem="GI5-Nb-w2x" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="trq-KW-6qD"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="tg4-Zy-Ih7"/>
                     <connections>
+                        <outlet property="emptyView" destination="GI5-Nb-w2x" id="4LR-a4-Uq7"/>
+                        <outlet property="emptyViewTopConstraint" destination="M8G-bx-Vj5" id="dsC-tO-2Jv"/>
                         <outlet property="goalCategoryCV" destination="zsx-4j-blm" id="FLm-gI-jAv"/>
                         <outlet property="writeHomeNaviBar" destination="Btg-DO-8q4" id="QB9-tY-rN4"/>
                         <outlet property="writeMainCV" destination="wNH-qz-TOz" id="eoR-Be-qaS"/>
@@ -109,8 +136,12 @@
     </scenes>
     <resources>
         <image name="btn_writing" width="84" height="84"/>
+        <image name="icNoting24" width="24" height="24"/>
         <namedColor name="grey_0">
             <color red="0.97254901960784312" green="0.98039215686274506" blue="0.98431372549019602" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="grey_5">
+            <color red="0.66666666666666663" green="0.68627450980392157" blue="0.70196078431372544" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/POME-iOS/POME-iOS/Screen/Write/VC/WriteVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Write/VC/WriteVC.swift
@@ -362,7 +362,7 @@ extension WriteVC {
                 if let data = data as? GetGoalDetailResModel {
                     DispatchQueue.main.async {
                         self.goalDetail = data
-                        self.writeMainCV.reloadSections(IndexSet(integer: 0))
+                        self.writeMainCV.reloadSections([0])
                     }
                 }
             case .requestErr:

--- a/POME-iOS/POME-iOS/Screen/Write/VC/WriteVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Write/VC/WriteVC.swift
@@ -13,11 +13,13 @@ class WriteVC: BaseVC {
     @IBOutlet weak var writeHomeNaviBar: PomeNaviBar!
     @IBOutlet weak var goalCategoryCV: UICollectionView!
     @IBOutlet weak var writeMainCV: UICollectionView!
+    @IBOutlet weak var emptyView: UIStackView!
+    @IBOutlet weak var emptyViewTopConstraint: NSLayoutConstraint!
     
     // MARK: Properties
     private var category: [GetGoalsResModel] = []
     private var goalDetail: GetGoalDetailResModel = GetGoalDetailResModel(id: 0, message: "", amount: 0, payAmount: 0, rate: 0, isPublic: true, dDay: 0)
-    private var spend: [String] = ["spend1", "spend2", "spend3", "spend4"]
+    private var spend: [String] = ["", "", ""]
     
     // MARK: Life Cycle
     override func viewDidLoad() {
@@ -31,6 +33,9 @@ class WriteVC: BaseVC {
         showTabbar()
         setCVOffset()
         getGoalGategory()
+        
+        // TODO: - 씀씀이 서버 통신 후 해당 코드 통신 부분으로 옮기기
+        configureEmptyView()
     }
     
     // MARK: IBAction
@@ -47,14 +52,20 @@ extension WriteVC {
         writeHomeNaviBar.setNaviStyle(state: .greyWithRightBtn)
     }
     
+    private func configureEmptyView() {
+        emptyViewTopConstraint.constant = 419.adjustedH
+        emptyView.isHidden = (spend.count != 0)
+    }
+    
     /// 목표 카테고리의 첫 아이템을 디폴트로 설정
     private func setGoalCategoryCV() {
         if category.count > 0 {
-            goalCategoryCV.selectItem(at: IndexPath(item: 1, section: 0), animated: false, scrollPosition: .right)
+            goalCategoryCV.selectItem(at: IndexPath(item: 1, section: 0), animated: true, scrollPosition: .right)
             
             /// 카테고리의 첫 번째 목표 id로 서버 통신
             getGoalDetail(goalId: category[0].id)
         }
+        writeMainCV.reloadData()
     }
     
     /// 컬렉션뷰 가장 위로 올림
@@ -205,9 +216,9 @@ extension WriteVC: UICollectionViewDataSource {
                             
                             /// 알럿창의 확인버튼(오른쪽 버튼) 누르는 경우 삭제 서버 통신
                             alert.confirmBtn.press { [weak self] in
-                                
-                                // TODO: - 삭제 서버 통신 필요
-                                print("목표카드 삭제합니다.")
+                                if let id = self?.goalDetail.id {
+                                    self?.deleteGoal(goalId: id)
+                                }
                                 self?.dismiss(animated: true)
                             }
                         })
@@ -221,6 +232,7 @@ extension WriteVC: UICollectionViewDataSource {
                 }
                 return feelingCardCVC
             default:
+                spendCVC.makeRounded(cornerRadius: 6.adjusted)
                 spendCVC.addShadow(offset: CGSize(width: 0, height: 0), color: .cellShadow, opacity: 0.12, radius: 4)
                 
                 /// 씀씀이 셀의 more 버튼을 누를 경우 action sheet를 띄운다.
@@ -273,7 +285,7 @@ extension WriteVC: UICollectionViewDelegateFlowLayout {
             case 1:
                 return CGSize(width: 343.adjusted, height: 118)
             default:
-                return CGSize(width: 166.adjusted, height: 188)
+                return CGSize(width: 166.adjusted, height: 188.adjustedH)
             }
         }
     }
@@ -350,8 +362,27 @@ extension WriteVC {
                 if let data = data as? GetGoalDetailResModel {
                     DispatchQueue.main.async {
                         self.goalDetail = data
-                        self.writeMainCV.reloadSections(IndexSet(0...1))
+                        self.writeMainCV.reloadSections(IndexSet(integer: 0))
                     }
+                }
+            case .requestErr:
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            default:
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            }
+        }
+    }
+    
+    /// 목표 삭제 요청 메서드
+    private func deleteGoal(goalId: Int) {
+        WriteAPI.shared.deleteGoalAPI(goalId: goalId) { networkResult in
+            switch networkResult {
+            case .success(_):
+                DispatchQueue.main.async {
+                    self.getGoalGategory()
+                    
+                    // TODO: - 씀씀이 api 붙이면 해당 코드 삭제 예정
+                    self.configureEmptyView()
                 }
             case .requestErr:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/POME-iOS/POME-iOS/Screen/Write/VC/WriteVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Write/VC/WriteVC.swift
@@ -33,9 +33,6 @@ class WriteVC: BaseVC {
         showTabbar()
         setCVOffset()
         getGoalGategory()
-        
-        // TODO: - 씀씀이 서버 통신 후 해당 코드 통신 부분으로 옮기기
-        configureEmptyView()
     }
     
     // MARK: IBAction
@@ -344,6 +341,9 @@ extension WriteVC {
                         self.category = data
                         self.goalCategoryCV.reloadData()
                         self.setGoalCategoryCV()
+                        
+                        // TODO: - 씀씀이 서버 통신 후 해당 코드 통신 부분으로 옮기기
+                        self.configureEmptyView()
                     }
                 }
             case .requestErr:
@@ -380,9 +380,6 @@ extension WriteVC {
             case .success(_):
                 DispatchQueue.main.async {
                     self.getGoalGategory()
-                    
-                    // TODO: - 씀씀이 api 붙이면 해당 코드 삭제 예정
-                    self.configureEmptyView()
                 }
             case .requestErr:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")


### PR DESCRIPTION
## 🍎 관련 이슈
closed #77 

## 🍎 변경 사항 및 이유
* 기록탭 메인 목표 삭제 api를 연결하였습니다.

## 🍎 PR Point
* 씀씀이 기록 없을 때의 emptyview 만들었습니다.
* 씀씀이 셀 크기 수정해주었습니다.
* 삭제 api 연결시 제네릭타입이 없는 오류가 있어서 deleteResModel 만들어주었습니다. response에 data가 없다면 해당 모델을 쓰면 될 것 같아요 ..~ 만약 삭제 api 말고도 data 없는 것이 있다면 네이밍은 수정하겠습니다.

## 📸 ScreenShot
https://user-images.githubusercontent.com/58043306/180023162-d0851e48-785c-48b1-a9d2-eebf2de47148.MP4


