### PR TITLE
✨ [FEAT] 로딩 뷰 삽입 및 다크모드 대응

### DIFF
--- a/POME-iOS/POME-iOS/Global/Class/BaseVC.swift
+++ b/POME-iOS/POME-iOS/Global/Class/BaseVC.swift
@@ -9,8 +9,24 @@ import UIKit
 
 class BaseVC: UIViewController {
 
+    // MARK: Properties
+    lazy var activityIndicator: UIActivityIndicatorView = {
+        let activityIndicator = UIActivityIndicatorView()
+        activityIndicator.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+        activityIndicator.center = view.center
+        
+        // 기타 옵션
+        activityIndicator.color = .main
+        activityIndicator.hidesWhenStopped = true
+        activityIndicator.style = .large
+        activityIndicator.stopAnimating()
+        
+        return activityIndicator
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.addSubview(activityIndicator)
     }
 }
 

--- a/POME-iOS/POME-iOS/Global/Extension/UIView+.swift
+++ b/POME-iOS/POME-iOS/Global/Extension/UIView+.swift
@@ -18,12 +18,16 @@ extension UIView {
     }
     
     /// UIView의 그림자를 설정하는 메서드
-    func addShadow(offset: CGSize, color: UIColor = .gray, opacity: Float = 0.1, radius: CGFloat = 3.0) {
+    func addShadow(offset: CGSize, color: UIColor = .gray, opacity: Float = 0.1, radius: CGFloat = 3.0, scale: Bool = true) {
         self.layer.masksToBounds = false
         self.layer.shadowColor = color.cgColor
         self.layer.shadowOffset = offset
         self.layer.shadowOpacity = opacity
         self.layer.shadowRadius = radius
+        
+        self.layer.shadowPath = UIBezierPath(rect: self.bounds).cgPath
+        self.layer.shouldRasterize = true
+        self.layer.rasterizationScale = scale ? UIScreen.main.scale : 1
     }
     
     /// 다수의 뷰를 한번에 addSubview해주는 메서드

--- a/POME-iOS/POME-iOS/Screen/Sign/VC/AddFriendVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Sign/VC/AddFriendVC.swift
@@ -183,6 +183,7 @@ extension AddFriendVC {
     
     /// 친구 검색 메서드
     private func searchMateNickname(nickname: String) {
+        self.activityIndicator.startAnimating()
         SignAPI.shared.searchMateAPI(nickname: nickname) { networkResult in
             switch networkResult {
             case .success(let data):
@@ -191,10 +192,13 @@ extension AddFriendVC {
                         self.profileList = data
                         self.profileTV.reloadData()
                     }
+                    self.activityIndicator.stopAnimating()
                 }
             case .requestErr:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
@@ -202,15 +206,16 @@ extension AddFriendVC {
     
     /// 친구 추가 요청 메서드
     private func addMate(targetID: Int) {
+        self.activityIndicator.startAnimating()
         SignAPI.shared.addMateAPI(targetID: targetID) { networkResult in
             switch networkResult {
             case .success(_):
-                
-                // TODO: 로딩뷰 멈춤
-                break
+                self.activityIndicator.stopAnimating()
             case .requestErr:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }

--- a/POME-iOS/POME-iOS/Screen/Sign/VC/SignInVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Sign/VC/SignInVC.swift
@@ -154,6 +154,7 @@ extension SignInVC {
     
     /// 카카오 로그인 요청 메서드
     private func requestKakaoLogin() {
+        self.activityIndicator.startAnimating()
         SignAPI.shared.requestLoginAPI() { networkResult in
             switch networkResult {
             case .success(let data):
@@ -163,16 +164,20 @@ extension SignInVC {
                     if data.type == "signup" {
                         UserDefaults.standard.set(data.uuid ?? "", forKey: UserDefaults.Keys.uuid)
                         self.presentMakeProfileVC()
+                        self.activityIndicator.stopAnimating()
                         
                     /// 이미 가입한 유저 -> 바로 로그인
                     } else {
                         self.setUserDefaultsValue(data: data)
                         self.presentMain()
+                        self.activityIndicator.stopAnimating()
                     }
                 }
             case .requestErr:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }

--- a/POME-iOS/POME-iOS/Screen/TabBar/VC/PomeTBC.swift
+++ b/POME-iOS/POME-iOS/Screen/TabBar/VC/PomeTBC.swift
@@ -26,8 +26,8 @@ extension PomeTBC {
         
         let tab = ViewControllerFactory.viewController(for: vcType)
         tab.tabBarItem = UITabBarItem(title: tabBarTitle,
-                                      image: UIImage(named: tabBarImg)?.withRenderingMode(.alwaysTemplate),
-                                      selectedImage: UIImage(named: tabBarSelectedImg)?.withRenderingMode(.alwaysTemplate))
+                                      image: UIImage(named: tabBarImg)?.withRenderingMode(.alwaysOriginal),
+                                      selectedImage: UIImage(named: tabBarSelectedImg)?.withRenderingMode(.alwaysOriginal))
         tab.tabBarItem.imageInsets = UIEdgeInsets(top: 2, left: 0, bottom: -2, right: 0)
         return tab
     }

--- a/POME-iOS/POME-iOS/Screen/Write/VC/WriteVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Write/VC/WriteVC.swift
@@ -339,6 +339,7 @@ extension WriteVC {
     
     /// 목표 카테고리 조회 요청 메서드
     private func getGoalGategory() {
+        self.activityIndicator.startAnimating()
         WriteAPI.shared.getGoalsAPI { networkResult in
             switch networkResult {
             case .success(let data):
@@ -348,10 +349,13 @@ extension WriteVC {
                         self.goalCategoryCV.reloadData()
                         self.setGoalCategoryCV()
                     }
+                    self.activityIndicator.stopAnimating()
                 }
             case .requestErr:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
@@ -359,6 +363,7 @@ extension WriteVC {
     
     /// 목표 상세 조회 요청 메서드
     private func getGoalDetail(goalId: Int) {
+        self.activityIndicator.startAnimating()
         WriteAPI.shared.getGoalDetailAPI(goalId: goalId) { networkResult in
             switch networkResult {
             case .success(let data):
@@ -367,6 +372,7 @@ extension WriteVC {
                         self.goalDetail = data
                         self.writeMainCV.reloadSections([0])
                     }
+                    self.activityIndicator.stopAnimating()
                 }
             case .requestErr:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
@@ -378,15 +384,19 @@ extension WriteVC {
     
     /// 목표 삭제 요청 메서드
     private func deleteGoal(goalId: Int) {
+        self.activityIndicator.startAnimating()
         WriteAPI.shared.deleteGoalAPI(goalId: goalId) { networkResult in
             switch networkResult {
             case .success(_):
                 DispatchQueue.main.async {
                     self.getGoalGategory()
                 }
+                self.activityIndicator.stopAnimating()
             case .requestErr:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
@@ -394,6 +404,7 @@ extension WriteVC {
     
     /// 일주일 씀씀이 조회 요청 메서드
     private func getWeekSpend(goalId: Int) {
+        self.activityIndicator.startAnimating()
         WriteAPI.shared.getWeekSpendAPI(goalId: goalId) { networkResult in
             switch networkResult {
             case .success(let data):
@@ -404,10 +415,13 @@ extension WriteVC {
                         self.writeMainCV.reloadSections([1, 2])
                         self.configureEmptyView()
                     }
+                    self.activityIndicator.stopAnimating()
                 }
             case .requestErr:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }

--- a/POME-iOS/POME-iOS/Support/SceneDelegate.swift
+++ b/POME-iOS/POME-iOS/Support/SceneDelegate.swift
@@ -24,6 +24,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             window.rootViewController = UIStoryboard.init(name: Identifiers.SignInSB, bundle: nil).instantiateViewController(withIdentifier: SignInVC.className) as? SignInVC
             
             self.window = window
+            window.overrideUserInterfaceStyle = .light 
             window.makeKeyAndVisible()
         }
     }

--- a/POME-iOS/Podfile
+++ b/POME-iOS/Podfile
@@ -10,7 +10,6 @@ target 'POME-iOS' do
   pod 'Then'
   pod 'Alamofire'
   pod 'FSCalendar'
-  pod 'lottie-ios'
   pod 'Kingfisher', '~> 7.0'
 
   pod 'KakaoSDKCommon'  # 필수 요소를 담은 공통 모듈

--- a/POME-iOS/Podfile.lock
+++ b/POME-iOS/Podfile.lock
@@ -13,7 +13,6 @@ PODS:
   - KakaoSDKUser (2.11.0):
     - KakaoSDKAuth (= 2.11.0)
   - Kingfisher (7.2.2)
-  - lottie-ios (3.3.0)
   - SnapKit (5.6.0)
   - Then (3.0.0)
 
@@ -24,7 +23,6 @@ DEPENDENCIES:
   - KakaoSDKCommon
   - KakaoSDKUser
   - Kingfisher (~> 7.0)
-  - lottie-ios
   - SnapKit (~> 5.6.0)
   - Then
 
@@ -36,7 +34,6 @@ SPEC REPOS:
     - KakaoSDKCommon
     - KakaoSDKUser
     - Kingfisher
-    - lottie-ios
     - SnapKit
     - Then
 
@@ -47,10 +44,9 @@ SPEC CHECKSUMS:
   KakaoSDKCommon: 0f59f2c1aead6012d92758e8ca46b63ea11c408b
   KakaoSDKUser: 5dbefe494c50dfdc87e4072710e503d39b41a609
   Kingfisher: 184d4d1a8c36666e663caf8e08abe87898595c53
-  lottie-ios: 6ac74dcc09904798f59b18cb3075c089d76be9ae
   SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
   Then: 844265ae87834bbe1147d91d5d41a404da2ec27d
 
-PODFILE CHECKSUM: 4014ab803fb096f904e744e8436bcd1845e3f1d6
+PODFILE CHECKSUM: 1195b0ae3d37c2777cfdad9cbd808b9d4c5b388a
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
## 🍎 관련 이슈
closed #93

## 🍎 변경 사항 및 이유
다크모드에도 라이트 모드와 똑같이 보이도록 설정해두었고, activity indicator를 넣어두었습니다.

## 🍎 PR Point
- lottie 파일에 이슈가 있어서 레전드 시간낭비를 했습니다...ㅋ...
lottie 라이브러리 설치를 해제 했으니 pull 이후에 pod install 한번 부탁드립니다!
- activity indicator를 baseVC에 설정해두어서 모든 VC에서 호출가능합니다.
시작 메서드: `self.activityIndicator.startAnimation`
멈춤 메서드: `self.activityIndicator.stopAnimation`

각자 서버통신부에 위의 코드를 이용, 제가 예시로 넣어놓은 것 참고해서 서버통신 시작과 끝 부분에 로딩뷰를 설정해주세요!!

## 📸 ScreenShot
