### PR TITLE
✨ [FEAT] 후순위 감정 남기기 API

### DIFF
--- a/POME-iOS/POME-iOS/Network/APIManagers/Write/WriteAPI.swift
+++ b/POME-iOS/POME-iOS/Network/APIManagers/Write/WriteAPI.swift
@@ -124,7 +124,7 @@ class WriteAPI: BaseAPI {
                 print(statusCode)
                 guard let data = response.data else { return }
                 
-                let networkResult = self.judgeStatus(by: statusCode, data, PostRecordResModel.self)
+                let networkResult = self.judgeStatus(by: statusCode, data, EmptyResModel.self)
                 completion(networkResult)
                 
             case .failure(let err):

--- a/POME-iOS/POME-iOS/Network/APIManagers/Write/WriteAPI.swift
+++ b/POME-iOS/POME-iOS/Network/APIManagers/Write/WriteAPI.swift
@@ -115,6 +115,24 @@ class WriteAPI: BaseAPI {
         }
     }
     
+    /// [PATCH] 나중 감정 등록
+    func patchLateEmotionAPI(endEmotion: Int, targetId: Int, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        AFmanager.request(WriteService.patchLateRecord(endEmotion: endEmotion, targetId: targetId)).responseData { response in
+            switch response.result {
+            case .success:
+                guard let statusCode = response.response?.statusCode else { return }
+                print(statusCode)
+                guard let data = response.data else { return }
+                
+                let networkResult = self.judgeStatus(by: statusCode, data, PostRecordResModel.self)
+                completion(networkResult)
+                
+            case .failure(let err):
+                print(err.localizedDescription)
+            }
+        }
+    }
+    
     /// [GET] 다시 돌아 볼 씀씀이 조회 API
     func getIncompleteRecordAPI(goalId: Int, completion: @escaping (NetworkResult<Any>) -> (Void)) {
         AFmanager.request(WriteService.getIncompleteRecord(goalId: goalId)).responseData { response in

--- a/POME-iOS/POME-iOS/Network/Services/Write/WriteService.swift
+++ b/POME-iOS/POME-iOS/Network/Services/Write/WriteService.swift
@@ -15,6 +15,7 @@ enum WriteService {
     case deleteGoal(goalId: Int)
     case getWeekRecord(goalId: Int)
     case postRecord(goalId: Int, date: String, amount: Int, content: String, startEmotion: Int)
+    case patchLateRecord(endEmotion: Int, targetId: Int)
     case getIncompleteRecord(goalId: Int)
 }
 
@@ -30,6 +31,8 @@ extension WriteService: TargetType {
             return "/records/week/\(goalId)"
         case .postRecord:
             return "/records"
+        case .patchLateRecord:
+            return "/records/emotion"
         case .getIncompleteRecord(let goalId):
             return "/records/incomplete/\(goalId)"
         }
@@ -43,6 +46,8 @@ extension WriteService: TargetType {
             return .delete
         case .postGoal, .postRecord:
             return .post
+        case .patchLateRecord:
+            return .patch
         }
     }
     
@@ -74,12 +79,18 @@ extension WriteService: TargetType {
                 "startEmotion": startEmotion
             ]
             return .requestBody(requestBody)
+        case .patchLateRecord(let endEmotion, let targetId):
+            let body: [String: Any] = [
+                "endEmotion": endEmotion,
+                "targetId": targetId
+            ]
+            return .requestBody(body)
         }
     }
     
     var header: HeaderType {
         switch self {
-        case .getGoalGategory, .getGoalDetail, .deleteGoal, .postGoal, .getWeekRecord, .postRecord, .getIncompleteRecord:
+        case .getGoalGategory, .getGoalDetail, .deleteGoal, .postGoal, .getWeekRecord, .postRecord, .getIncompleteRecord, .patchLateRecord:
             return .auth
         }
     }

--- a/POME-iOS/POME-iOS/Screen/Mate/VC/MateVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Mate/VC/MateVC.swift
@@ -366,6 +366,7 @@ extension MateVC {
     
     /// 상단의 친구 목록 요청
     private func requestGetMateAPI() {
+        self.activityIndicator.startAnimating()
         MateAPI.shared.requestGetMateAPI() {
             networkResult in
             switch networkResult {
@@ -375,11 +376,14 @@ extension MateVC {
                         self.mateDataList = data
                         self.mateProfileCV.reloadData()
                     }
+                    self.activityIndicator.stopAnimating()
                 }
             case .requestErr:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             default:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             }
             self.mateProfileCV.reloadData()
         }
@@ -389,6 +393,7 @@ extension MateVC {
     private func getMateRecord(mateId: Int) {
         self.activityIndicator.startAnimating()
         MateAPI.shared.getMateRecordAPI(userId: mateId) { networkResult in
+            self.activityIndicator.startAnimating()
             switch networkResult {
             case .success(let data):
                 if let data = data as? [GetMateRecordResModel] {
@@ -401,8 +406,10 @@ extension MateVC {
                 }
             case .requestErr:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             default:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             }
         }
     }

--- a/POME-iOS/POME-iOS/Screen/Mypage/VC/GoalStorageVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Mypage/VC/GoalStorageVC.swift
@@ -185,6 +185,7 @@ extension GoalStorageVC {
     
     /// 목표보관함 요청
     private func requestGoalStorageAPI() {
+        self.activityIndicator.startAnimating()
         MypageAPI.shared.requestGoalStorageAPI() { networkResult in
             switch networkResult {
             case .success(let data):
@@ -193,24 +194,30 @@ extension GoalStorageVC {
                     self.goalStorageDataList = data
                     self.goalStorageCV.reloadData()
                 }
+                self.activityIndicator.stopAnimating()
             case .requestErr:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             default:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             }
         }
     }
     
     /// 목표보관함 삭제
     private func requestDeleteGoalAPI(goalId: Int) {
+        self.activityIndicator.startAnimating()
         MypageAPI.shared.requestDeleteGoalAPI(goalId: goalId) { networkResult in
             switch networkResult {
             case .success(_):
                 self.requestGoalStorageAPI()
             case .requestErr:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             default:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             }
         }
     }

--- a/POME-iOS/POME-iOS/Screen/Mypage/VC/MypageVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Mypage/VC/MypageVC.swift
@@ -197,6 +197,7 @@ extension MypageVC {
     
     /// 마이페이지 유저 정보
     private func requestUser() {
+        self.activityIndicator.startAnimating()
         MypageAPI.shared.requestUserAPI {
             networkResult in
             switch networkResult {
@@ -208,10 +209,13 @@ extension MypageVC {
                     self.setData(data: self.UserData)
                     self.marshmellowCV.reloadData()
                 }
+                self.activityIndicator.stopAnimating()
             case .requestErr:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             default:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             }
         }
     }

--- a/POME-iOS/POME-iOS/Screen/Remind/Cell/TVC/RemindHaveNoGoalTVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Remind/Cell/TVC/RemindHaveNoGoalTVC.swift
@@ -45,9 +45,9 @@ extension RemindHaveNoGoalTVC {
         
         blankImageView.snp.makeConstraints {
             if UIScreen.main.bounds.height < 812 {
-                $0.top.equalToSuperview().inset(130)
+                $0.top.equalToSuperview().offset(130)
             } else {
-                $0.centerY.equalToSuperview().offset(158)
+                $0.centerY.equalToSuperview().offset(130)
             }
             $0.centerX.equalToSuperview()
         }

--- a/POME-iOS/POME-iOS/Screen/Remind/VC/RemindVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Remind/VC/RemindVC.swift
@@ -47,13 +47,12 @@ class RemindVC: BaseVC {
         configureUI()
         registerCell()
         setDelegate()
-        setTVScroll()
-        requestGetRemind()
     }
     
     /// 탭바가 왔다갔다 할 경우 첫 셀이 default가 되게끔 처리하였다.
     override func viewWillAppear(_ animated: Bool) {
         requestGetRemind()
+        setTVScroll()
     }
 }
 
@@ -110,7 +109,7 @@ extension RemindVC {
     
     /// 목표가 없을때는 스크롤이 안되도록 막아두었다.
     private func setTVScroll() {
-        remindTV.isScrollEnabled = (category.count == 0) ? false : true
+        remindTV.isScrollEnabled = (goalRecordList.count == 0) ? false : true
     }
     
     /// 목표 카테고리의 다른탭으로 눌리기 전의 탭으로 눌리게끔 default 설정
@@ -418,6 +417,7 @@ extension RemindVC {
                     DispatchQueue.main.async {
                         self.goalRecordList = data
                         self.remindTV.reloadData()
+                        self.setTVScroll()
                     }
                 }
             case .requestErr:

--- a/POME-iOS/POME-iOS/Screen/Remind/VC/RemindVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Remind/VC/RemindVC.swift
@@ -387,6 +387,7 @@ extension RemindVC {
     
     /// 상단의 카테고리 목록 요청
     private func requestGetRemind() {
+        self.activityIndicator.startAnimating()
         RemindAPI.shared.requestGetRemindGoalAPI() {
             networkResult in
             switch networkResult {
@@ -398,17 +399,21 @@ extension RemindVC {
                         self.goalCategoryCV.reloadData()
                         self.setDefaultSelectedCell(index: self.selectedCategoryIndex)
                     }
+                    self.activityIndicator.stopAnimating()
                 }
             case .requestErr:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             default:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             }
         }
     }
     
     /// 상단의 카테고리에 따른 목표 리스트 요청
     private func reqeustGetRemindGoal(goalId: Int) {
+        self.activityIndicator.startAnimating()
         RemindAPI.shared.requestGetRemindGoalListAPI(goalId: goalId) {
             networkResult in
             switch networkResult {
@@ -419,11 +424,14 @@ extension RemindVC {
                         self.remindTV.reloadData()
                         self.setTVScroll()
                     }
+                    self.activityIndicator.stopAnimating()
                 }
             case .requestErr:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             default:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             }
         }
     }

--- a/POME-iOS/POME-iOS/Screen/Write/VC/LookbackCompleteVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Write/VC/LookbackCompleteVC.swift
@@ -10,9 +10,9 @@ import UIKit
 class LookbackCompleteVC: BaseVC {
     
     // MARK: Properties
-    private let price: String = "35,200"
-    private let firstFeeling: Int = 1
-    private let secondFeeling: Int = 3
+    var amount: Int = 0
+    var startEmotion: Int = 0
+    var endEmotion: Int = 0
 
     // MARK: IBOutlet
     @IBOutlet weak var completeBtn: PomeBtn!
@@ -72,11 +72,9 @@ extension LookbackCompleteVC {
     }
     
     private func setData() {
+        priceLabel.text = "\(numberFormatter(number: amount))원을 사용했어요"
         
-        // TODO: - 서버 통신 할 때 데이터 형식 Int or String 인지 확인하기
-        priceLabel.text = price + "원을 사용했어요"
-        
-        switch firstFeeling {
+        switch startEmotion {
         case 1:
             firstEmojiImageView.image = UIImage(named: "icHeartCircle52")
             firstTitleLabel.text = "씀씀이 당시 행복했어요"
@@ -91,7 +89,7 @@ extension LookbackCompleteVC {
             firstSubLabel.text = "괜찮아요. 다음 번엔 조금 더 고민해봐요!"
         }
         
-        switch secondFeeling {
+        switch endEmotion {
         case 1:
             secondEmojiImageView.image = UIImage(named: "icHeartCirclePink52")
             secondTitleLabel.text = "일주일 뒤 행복했어요"

--- a/POME-iOS/POME-iOS/Screen/Write/VC/LookbackVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Write/VC/LookbackVC.swift
@@ -126,6 +126,8 @@ extension LookbackVC: UICollectionViewDataSource {
                 
                 spendCVC.tapPlusBtn = {
                     guard let lookbackSelectVC = UIStoryboard.init(name: Identifiers.WriteSelectFeelingSB, bundle: nil).instantiateViewController(withIdentifier: WriteSelectFeelingVC.className) as? WriteSelectFeelingVC else { return }
+                    lookbackSelectVC.lateRecord = self.record[indexPath.row]
+                    
                     self.navigationController?.pushViewController(lookbackSelectVC, animated: true)
                 }
             }

--- a/POME-iOS/POME-iOS/Screen/Write/VC/WriteSelectFeelingVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Write/VC/WriteSelectFeelingVC.swift
@@ -15,7 +15,7 @@ class WriteSelectFeelingVC: BaseVC {
     
     /// 씀씀이 기록 추가 서버 통신을 위해 이전 VC에서 받아 올 정보
     var newRecord: PostRecordResModel = PostRecordResModel(id: 0, date: "", amount: 0, content: "", startEmotion: 0)
-    var lateRecord: PatchRecordResModel = PatchRecordResModel(id: 0, amount: 0, startEmotion: 0, endEmotion: 0)
+    var lateRecord: Record = Record(id: 0, date: "", amount: 0, content: "", startEmotion: 0, endEmotion: 0)
     
     // MARK: IBOutlet
     @IBOutlet weak var naviBar: PomeNaviBar!
@@ -87,10 +87,7 @@ class WriteSelectFeelingVC: BaseVC {
         if isRecord {
             postRecord(goalId: newRecord.id, date: newRecord.date, amount: newRecord.amount, content: newRecord.content, startEmotion: selectedEmotion)
         } else {
-
-            patchLateRecord(endEmotion: lateRecord.endEmotion, targetId: lateRecord.)
-            // TODO: - 나중 감정 추가 서버 통신 필요, 아래 코드는 통신 후 success로 이동
-            presentLookbackCompleteVC()
+            patchLateRecord(endEmotion: selectedEmotion, targetId: lateRecord.id)
         }
     }
 }
@@ -174,6 +171,10 @@ extension WriteSelectFeelingVC {
     /// 되돌아보기 - 나중감정 남긴 후 띄울 뷰
     private func presentLookbackCompleteVC() {
         guard let lookbackCompleteVC = UIStoryboard.init(name: Identifiers.LookbackCompleteSB, bundle: nil).instantiateViewController(withIdentifier: LookbackCompleteVC.className) as? LookbackCompleteVC else { return }
+        lookbackCompleteVC.amount = lateRecord.amount
+        lookbackCompleteVC.startEmotion = lateRecord.startEmotion
+        lookbackCompleteVC.endEmotion = selectedEmotion
+        
         navigationController?.pushViewController(lookbackCompleteVC, animated: true)
     }
 }
@@ -195,6 +196,7 @@ extension WriteSelectFeelingVC {
         }
     }
     
+    /// 나중 기록 작성 요청 메서드
     private func patchLateRecord(endEmotion: Int, targetId: Int) {
         WriteAPI.shared.patchLateEmotionAPI(endEmotion: endEmotion, targetId: targetId) {
             networkResult in

--- a/POME-iOS/POME-iOS/Screen/Write/VC/WriteSelectFeelingVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Write/VC/WriteSelectFeelingVC.swift
@@ -184,13 +184,17 @@ extension WriteSelectFeelingVC {
     
     /// 기록 씀씀이 추가 요청 메서드
     private func postRecord(goalId: Int, date: String, amount: Int, content: String, startEmotion: Int) {
+        self.activityIndicator.startAnimating()
         WriteAPI.shared.postRecordAPI(goalId: goalId, date: date, amount: amount, content: content, startEmotion: startEmotion) { networkResult in
             switch networkResult {
             case .success(_):
+                self.activityIndicator.stopAnimating()
                 self.presentAddRecordCompleteVC()
             case .requestErr:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
@@ -198,14 +202,18 @@ extension WriteSelectFeelingVC {
     
     /// 나중 기록 작성 요청 메서드
     private func patchLateRecord(endEmotion: Int, targetId: Int) {
+        self.activityIndicator.startAnimating()
         WriteAPI.shared.patchLateEmotionAPI(endEmotion: endEmotion, targetId: targetId) {
             networkResult in
             switch networkResult {
             case .success(_):
                 self.presentLookbackCompleteVC()
+                self.activityIndicator.stopAnimating()
             case .requestErr:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }

--- a/POME-iOS/POME-iOS/Screen/Write/VC/WriteSelectFeelingVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Write/VC/WriteSelectFeelingVC.swift
@@ -15,6 +15,7 @@ class WriteSelectFeelingVC: BaseVC {
     
     /// 씀씀이 기록 추가 서버 통신을 위해 이전 VC에서 받아 올 정보
     var newRecord: PostRecordResModel = PostRecordResModel(id: 0, date: "", amount: 0, content: "", startEmotion: 0)
+    var lateRecord: PatchRecordResModel = PatchRecordResModel(id: 0, amount: 0, startEmotion: 0, endEmotion: 0)
     
     // MARK: IBOutlet
     @IBOutlet weak var naviBar: PomeNaviBar!
@@ -87,6 +88,7 @@ class WriteSelectFeelingVC: BaseVC {
             postRecord(goalId: newRecord.id, date: newRecord.date, amount: newRecord.amount, content: newRecord.content, startEmotion: selectedEmotion)
         } else {
 
+            patchLateRecord(endEmotion: lateRecord.endEmotion, targetId: lateRecord.)
             // TODO: - 나중 감정 추가 서버 통신 필요, 아래 코드는 통신 후 success로 이동
             presentLookbackCompleteVC()
         }
@@ -185,6 +187,20 @@ extension WriteSelectFeelingVC {
             switch networkResult {
             case .success(_):
                 self.presentAddRecordCompleteVC()
+            case .requestErr:
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            default:
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            }
+        }
+    }
+    
+    private func patchLateRecord(endEmotion: Int, targetId: Int) {
+        WriteAPI.shared.patchLateEmotionAPI(endEmotion: endEmotion, targetId: targetId) {
+            networkResult in
+            switch networkResult {
+            case .success(_):
+                self.presentLookbackCompleteVC()
             case .requestErr:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:

--- a/POME-iOS/POME-iOS/Screen/Write/VC/WriteVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Write/VC/WriteVC.swift
@@ -382,11 +382,11 @@ extension WriteVC {
                     self.activityIndicator.stopAnimating()
                 }
             case .requestErr:
-                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             default:
-                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             }
         }
     }
@@ -406,8 +406,10 @@ extension WriteVC {
                 }
             case .requestErr:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             default:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             }
         }
     }
@@ -428,11 +430,11 @@ extension WriteVC {
                 }
                 self.activityIndicator.stopAnimating()
             case .requestErr:
-                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             default:
-                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             }
         }
     }
@@ -453,11 +455,11 @@ extension WriteVC {
                     self.activityIndicator.stopAnimating()
                 }
             case .requestErr:
-                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             default:
-                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.activityIndicator.stopAnimating()
             }
         }
     }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #107 

## 🍎 변경 사항 및 이유
- 빈셀일때, 문구 위치 변경
- 회고탭 첫셀은 데이터가 0 이여서 스크롤이 안되고, 다른 목표들은 셀이 있는 경우  스크롤이 되지 않는 현상 해결
- 후순위 감정 남기기 API 연결 ( 주현이가 다도와줌 .. )
- 인디케이터 생성

## 🍎 PR Point
주현이가 서버 붙이는걸 다 도와주었습니다..사랑해 ..알라뷰 .. 
회고탭 첫셀은 데이터가 0 이여서 스크롤이 안되고, 다른 목표들은 셀이 있는 경우  스크롤이 되지 않는 현상 
: 주현이가 .. 바로 호다닥 고쳐주었습니다 .. 주현아 앱잼기간 계속 미안하고 사랑해 .. 알라뷰 .. 

얘들아 .. 앱잼기간때 큰도움 못줘서 넘 미안하고 .. 고맙고 흑흑 사랑해❤️

## 📸 ScreenShot
|`플로우`|
|![Simulator Screen Recording - iPhone 13 Pro Max - 2022-07-23 at 05 53 27](https://user-images.githubusercontent.com/78431728/180567923-cdef0b5c-f130-47e2-b4c3-a78b7e172176.gif)|

|`회고탭 빈셀`|`친구탭 빈셀`|
|----------------|----------------|
|![Simulator Screen Shot - iPhone 13 Pro Max - 2022-07-23 at 05 53 34](https://user-images.githubusercontent.com/78431728/180567958-a8d7f65f-732a-435d-b287-b6e6eb6ac677.png)|![Simulator Screen Shot - iPhone 13 Pro Max - 2022-07-23 at 05 54 09](https://user-images.githubusercontent.com/78431728/180567974-9e1983d9-5a8c-4854-9104-4f43d90202bd.png)|
