### PR TITLE
✨ [FEAT] 일주일 씀씀이 기록 삭제, 되돌아보기 기록 삭제 api 연결

### DIFF
--- a/POME-iOS/POME-iOS/Network/APIManagers/Write/WriteAPI.swift
+++ b/POME-iOS/POME-iOS/Network/APIManagers/Write/WriteAPI.swift
@@ -131,4 +131,21 @@ class WriteAPI: BaseAPI {
             }
         }
     }
+    
+    /// [DEETE] 기록 삭제 API
+    func deleteRecordAPI(goalId: Int, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        AFmanager.request(WriteService.deleteRecord(goalId: goalId)).responseData { response in
+            switch response.result {
+            case .success:
+                guard let statusCode = response.response?.statusCode else { return }
+                guard let data = response.data else { return }
+                
+                let networkResult = self.judgeStatus(by: statusCode, data, EmptyResModel.self)
+                completion(networkResult)
+                
+            case .failure(let err):
+                print(err.localizedDescription)
+            }
+        }
+    }
 }

--- a/POME-iOS/POME-iOS/Network/Services/Write/WriteService.swift
+++ b/POME-iOS/POME-iOS/Network/Services/Write/WriteService.swift
@@ -16,6 +16,7 @@ enum WriteService {
     case getWeekRecord(goalId: Int)
     case postRecord(goalId: Int, date: String, amount: Int, content: String, startEmotion: Int)
     case getIncompleteRecord(goalId: Int)
+    case deleteRecord(goalId: Int)
 }
 
 extension WriteService: TargetType {
@@ -32,6 +33,8 @@ extension WriteService: TargetType {
             return "/records"
         case .getIncompleteRecord(let goalId):
             return "/records/incomplete/\(goalId)"
+        case .deleteRecord(let goalId):
+            return "/records/\(goalId)"
         }
     }
     
@@ -39,7 +42,7 @@ extension WriteService: TargetType {
         switch self {
         case .getGoalGategory, .getGoalDetail, .getWeekRecord, .getIncompleteRecord:
             return .get
-        case .deleteGoal:
+        case .deleteGoal, .deleteRecord:
             return .delete
         case .postGoal, .postRecord:
             return .post
@@ -50,7 +53,7 @@ extension WriteService: TargetType {
         switch self {
         case .getGoalGategory:
             return .requestPlain
-        case .getGoalDetail(let goalId), .deleteGoal(let goalId), .getWeekRecord(let goalId), .getIncompleteRecord(let goalId):
+        case .getGoalDetail(let goalId), .deleteGoal(let goalId), .getWeekRecord(let goalId), .getIncompleteRecord(let goalId), .deleteRecord(let goalId):
             let requestQuery: [String: Any] = [
                 "goalId": goalId
             ]
@@ -79,7 +82,7 @@ extension WriteService: TargetType {
     
     var header: HeaderType {
         switch self {
-        case .getGoalGategory, .getGoalDetail, .deleteGoal, .postGoal, .getWeekRecord, .postRecord, .getIncompleteRecord:
+        case .getGoalGategory, .getGoalDetail, .deleteGoal, .postGoal, .getWeekRecord, .postRecord, .getIncompleteRecord, .deleteRecord:
             return .auth
         }
     }

--- a/POME-iOS/POME-iOS/Screen/Write/VC/LookbackVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Write/VC/LookbackVC.swift
@@ -116,11 +116,9 @@ extension LookbackVC: UICollectionViewDataSource {
                         
                         /// 알럿창의 확인버튼(오른쪽 버튼) 누르는 경우 삭제 서버 통신
                         alert.confirmBtn.press { [weak self] in
-                            
-                            // TODO: - 삭제 서버 통신 필요
-                            print("씀씀이 삭제합니다.")
-                            self?.dismiss(animated: true)
+                            self?.deleteRecord(goalId: (self?.record[indexPath.row].id)!)
                         }
+
                     })
                 }
                 
@@ -183,6 +181,29 @@ extension LookbackVC {
                     }
                     self.activityIndicator.stopAnimating()
                 }
+            case .requestErr:
+                self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            default:
+                self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            }
+        }
+    }
+    
+    /// 기록 삭제 요청 메서드
+    private func deleteRecord(goalId: Int) {
+        self.activityIndicator.startAnimating()
+        WriteAPI.shared.deleteRecordAPI(goalId: goalId) { networkResult in
+            switch networkResult {
+            case .success(_):
+                DispatchQueue.main.async {
+                    self.getIncompleteRecord(goalId: self.selectedGoalId)
+                    self.lookbackMainCV.reloadSections([1])
+                    self.configureEmptyView()
+                }
+                self.dismiss(animated: true)
+                self.activityIndicator.stopAnimating()
             case .requestErr:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/POME-iOS/POME-iOS/Screen/Write/VC/WriteVC.swift
+++ b/POME-iOS/POME-iOS/Screen/Write/VC/WriteVC.swift
@@ -467,7 +467,8 @@ extension WriteVC {
             case .success(_):
                 DispatchQueue.main.async {
                     self.getWeekSpend(goalId: self.goalDetail.id)
-                    self.writeMainCV.reloadSections([2])
+                    self.getGoalDetail(goalId: self.goalDetail.id)
+                    self.writeMainCV.reloadSections([1, 2])
                     self.configureEmptyView()
                 }
                 self.dismiss(animated: true)


### PR DESCRIPTION
## 🍎 관련 이슈
closed #117 

## 🍎 변경 사항 및 이유
일주일 씀씀이 기록 삭제, 되돌아보기 기록 삭제 api를 연결하였습니다.

## 🍎 PR Point
삭제 시 엠티뷰, 상단 목표 카드 데이터 다시 받아서 reload 해주었습니다.

## 📸 ScreenShot
https://user-images.githubusercontent.com/58043306/180572059-9edc2407-4632-45c1-af83-2c352cfec1ce.MP4
